### PR TITLE
38 enforce unique economy id values

### DIFF
--- a/R/add_entity_pattern.R
+++ b/R/add_entity_pattern.R
@@ -48,6 +48,26 @@ add_entity_pattern <- function(
   aliases = NULL,
   entity_regex = NULL
 ) {
+  # Ensure the custom patterns object exists in the environment.
+  if (!exists("custom_entity_patterns", envir = .econid_env)) {
+    .econid_env$custom_entity_patterns <- tibble::tibble(
+      entity_id    = character(),
+      entity_name  = character(),
+      iso3c         = character(),
+      iso2c         = character(),
+      entity_type  = character(),
+      entity_regex = character()
+    )
+  } else {
+    # Validate that the entity_id is not already in the patterns
+    if (entity_id %in% list_entity_patterns()$entity_id) {
+      stop(
+        "The entity_id '", entity_id, "' already exists in the custom ",
+        "patterns. Please use a unique identifier."
+      )
+    }
+  }
+
   # If no custom regex is supplied, build one from aliases (or default to
   # "entity_id|entity_name")
   if (is.null(entity_regex)) {
@@ -70,18 +90,6 @@ add_entity_pattern <- function(
     entity_type = entity_type,
     entity_regex = entity_regex
   )
-
-  # Ensure the custom patterns object exists in the environment.
-  if (!exists("custom_entity_patterns", envir = .econid_env)) {
-    .econid_env$custom_entity_patterns <- tibble::tibble(
-      entity_id    = character(),
-      entity_name  = character(),
-      iso3c         = character(),
-      iso2c         = character(),
-      entity_type  = character(),
-      entity_regex = character()
-    )
-  }
 
   # Retrieve, update, and reassign
   current_custom <- .econid_env$custom_entity_patterns

--- a/R/list_entity_patterns.R
+++ b/R/list_entity_patterns.R
@@ -22,7 +22,7 @@
 #' @keywords internal
 list_entity_patterns <- function() {
   # Get built-in patterns
-  builtin <- econid::entity_patterns
+  builtin <- entity_patterns
 
   # Create the .econid_env if it doesn't exist
   if (!exists(".econid_env", mode = "environment")) {

--- a/R/standardize_entity.R
+++ b/R/standardize_entity.R
@@ -181,6 +181,28 @@ standardize_entity <- function(
         output_col
       }
 
+      # If it's the entity_id column, we need to validate that the values being
+      # filled (i.e., in masked rows) are not already in entity_patterns
+      if (output_col == "entity_id") {
+        # Get the entity_id values that are already in entity_patterns
+        existing_ids <- entity_patterns[1]
+
+        # Get the entity_id values that are being filled
+        filled_ids <- results[[input_col]][no_match_mask]
+
+        # Check if any of the filled ids are already in existing_ids
+        if (any(filled_ids %in% existing_ids)) {
+          cli::cli_warn(paste(
+            "The entity_id value(s)",
+            filled_ids[which(filled_ids %in% existing_ids)],
+            "being filled over from",
+            input_col,
+            "already exists in the entity_patterns data frame.",
+            "Please use a unique identifier."
+          ))
+        }
+      }
+
       # Only apply mapping if output column exists
       if (prefixed_output %in% names(results)) {
         # Fill NA values in the output column with values from the input column

--- a/R/standardize_entity.R
+++ b/R/standardize_entity.R
@@ -183,9 +183,9 @@ standardize_entity <- function(
 
       # If it's the entity_id column, we need to validate that the values being
       # filled (i.e., in masked rows) are not already in entity_patterns
-      if (output_col == "entity_id") {
+      if (warn_ambiguous && output_col == "entity_id") {
         # Get the entity_id values that are already in entity_patterns
-        existing_ids <- entity_patterns[1]
+        existing_ids <- entity_patterns[[1]]
 
         # Get the entity_id values that are being filled
         filled_ids <- results[[input_col]][no_match_mask]
@@ -197,7 +197,7 @@ standardize_entity <- function(
             filled_ids[which(filled_ids %in% existing_ids)],
             "being filled over from",
             input_col,
-            "already exists in the entity_patterns data frame.",
+            "conflict(s) with a standard entity ID, which may cause ambiguity.",
             "Please use a unique identifier."
           ))
         }

--- a/tests/testthat/test-add_entity_pattern.R
+++ b/tests/testthat/test-add_entity_pattern.R
@@ -170,3 +170,63 @@ test_that("returns invisible NULL", {
   expect_null(vis$value)
   expect_false(vis$visible)
 })
+
+test_that("error is thrown when duplicating default pattern entity_id", {
+  local_clean_econid_patterns()
+
+  # Mock the default patterns
+  local_mocked_bindings(
+    list_entity_patterns = function() {
+      tibble::tibble(
+        entity_id = "duplicate_id1",
+        entity_name = "Original Entity",
+        iso3c = "ORI",
+        iso2c = "OR",
+        entity_type = "economy",
+        entity_regex = "original_regex"
+      )
+    }
+  )
+
+  # Try to add a duplicate of the default pattern and expect an error
+  expect_error(
+    add_entity_pattern(
+      entity_id = "duplicate_id1",
+      entity_name = "Original Entity",
+      entity_type = "economy"
+    ),
+    paste0(
+      "The entity_id 'duplicate_id1' already exists in the custom ",
+      "patterns. Please use a unique identifier."
+    )
+  )
+})
+
+test_that("error is thrown when duplicating custom pattern entity_id", {
+  local_clean_econid_patterns()
+
+  # Add a custom pattern
+  add_entity_pattern(
+    entity_id = "duplicate_id2",
+    entity_name = "Original Entity",
+    entity_type = "economy"
+  )
+
+  # Try to add another with the same entity_id
+  expect_error(
+    add_entity_pattern(
+      entity_id = "duplicate_id2",
+      entity_name = "Different Entity", 
+      entity_type = "organization"
+    ),
+    paste0(
+      "The entity_id 'duplicate_id2' already exists in the custom ",
+      "patterns. Please use a unique identifier."
+    )
+  )
+
+  # Verify only one pattern was added
+  cp <- get("custom_entity_patterns", envir = .econid_env)
+  expect_equal(nrow(cp), 1)
+  expect_equal(cp$entity_name[1], "Original Entity")
+})

--- a/tests/testthat/test-add_entity_pattern.R
+++ b/tests/testthat/test-add_entity_pattern.R
@@ -216,7 +216,7 @@ test_that("error is thrown when duplicating custom pattern entity_id", {
   expect_error(
     add_entity_pattern(
       entity_id = "duplicate_id2",
-      entity_name = "Different Entity", 
+      entity_name = "Different Entity",
       entity_type = "organization"
     ),
     paste0(

--- a/tests/testthat/test-standardize-entity.R
+++ b/tests/testthat/test-standardize-entity.R
@@ -1020,20 +1020,17 @@ test_that("fill_mapping validates uniqueness of entity_id values", {
     "NotACountry", "USA"  # Using "USA" which already exists in entity_patterns
   )
 
-  # Mock the entity_patterns to have a controlled set of IDs
-  mock_patterns <- tibble::tibble(
-    entity_id = c("USA", "FRA", "DEU"),
-    entity_name = c("United States", "France", "Germany"),
-    entity_type = c("economy", "economy", "economy"),
-    iso3c = c("USA", "FRA", "DEU"),
-    iso2c = c("US", "FR", "DE"),
-    entity_regex = c("^united states|us$", "^france|fra$", "^germany|deu$")
-  )
-
   # Use local_mocked_bindings to mock list_entity_patterns
   local_mocked_bindings(
     list_entity_patterns = function() {
-      mock_patterns
+      tibble::tibble(
+        entity_id = c("USA", "FRA", "DEU"),
+        entity_name = c("United States", "France", "Germany"),
+        entity_type = c("economy", "economy", "economy"),
+        iso3c = c("USA", "FRA", "DEU"),
+        iso2c = c("US", "FR", "DE"),
+        entity_regex = c("^united states|us$", "^france|fra$", "^germany|deu$")
+      )
     }
   )
 
@@ -1044,7 +1041,7 @@ test_that("fill_mapping validates uniqueness of entity_id values", {
       entity,
       fill_mapping = c(entity_id = "code")  # "code" contains "USA"
     ),
-    "already exists in the entity_patterns"
+    "The entity_id value"
   )
 
   #But should still perform the fill
@@ -1059,7 +1056,7 @@ test_that("fill_mapping validates uniqueness of entity_id values", {
   # This should work fine
   result <- standardize_entity(
     test_df2,
-    entity, code,
+    entity,
     fill_mapping = c(entity_id = "code")
   )
 


### PR DESCRIPTION
- Validate that entities added to `entity_patterns` with `add_entity_pattern` have unique ids, and stop if there's a conflict
- Validate that entity ids filled over from a fill_mapping column in unmatched rows are unique, and warn if there's a conflict
  - Perform this second check only if `warn_ambiguous` is true, since it introduces a little overhead and is likely a very rare case
- Add test coverage for the above validations