### PR TITLE
51 release econid 001

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^.specstory$
 ^bench$
 ^README_files$
+^cran-comments\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,22 +11,15 @@ RoxygenNote: 7.3.2
 Imports: 
     cli,
     dplyr,
+    purrr,
     fuzzyjoin,
     rlang,
-    tibble
+    tibble,
+    tidyr
 Suggests:
     testthat (>= 3.0.0),
-    devtools (>= 2.4.5),
-    lintr (>= 3.1.2),
-    dotenv,
-    tidyr,
-    ellmer,
-    purrr,
     stringr,
-    renv,
-    withr,
-    covr,
-    DT
+    withr
 Config/testthat/edition: 3
 URL: https://teal-insights.github.io/r-econid/, https://github.com/Teal-Insights/r-econid
 BugReports: https://github.com/Teal-Insights/r-econid/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: econid
-Title: Economic Entity Name and ID Standardization
+Title: Economic Entity Identifier Standardization
 Version: 0.0.1
 Authors@R: 
     c(person("Teal Insights", email = "lte@tealinsights.com", role = c("aut", "cre", "cph")))
-Description: Provides standardized entity (economy, aggregate, institution, etc.) name and id mappings for working with economic data published by the IMF and World Bank. Aims to facilitate consistent data analysis and reporting.
+Description: Provides utility functions for standardizing economic entity (economy, aggregate, institution, etc.) name and id in economic datasets such as those published by the International Monetary Fund and World Bank. Aims to facilitate consistent data analysis, reporting, and joining across datasets. Used as a foundational building block in the 'econdataverse' family of packages (<https://www.econdataverse.org>).
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: econid
-Title: Standardized Geography for Economists
-Version: 0.0.1.9003
+Title: Economic Entity Name and ID Standardization
+Version: 0.0.1
 Authors@R: 
     c(person("Teal Insights", email = "lte@tealinsights.com", role = c("aut", "cre", "cph")))
 Description: Provides standardized entity (economy, aggregate, institution, etc.) name and id mappings for working with economic data published by the IMF and World Bank. Aims to facilitate consistent data analysis and reporting.
@@ -28,7 +28,7 @@ Suggests:
     covr,
     DT
 Config/testthat/edition: 3
-URL: https://teal-insights.github.io/r-econid, https://github.com/Teal-Insights/r-econid, https://teal-insights.github.io/r-econid/
+URL: https://teal-insights.github.io/r-econid/, https://github.com/Teal-Insights/r-econid
 BugReports: https://github.com/Teal-Insights/r-econid/issues
 Depends: 
     R (>= 4.1.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# econid (development version)
+
+* Initial CRAN submission.

--- a/R/list_entity_patterns.R
+++ b/R/list_entity_patterns.R
@@ -19,7 +19,6 @@
 #' patterns <- list_entity_patterns()
 #'
 #' @export
-#' @keywords internal
 list_entity_patterns <- function() {
   # Get built-in patterns
   builtin <- entity_patterns

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<a href="https://teal-insights.github.io/r-econid"><img src="man/figures/logo.png" align="right" height="40" alt="r-econid website" /></a>
+<a href="https://teal-insights.github.io/r-econid/"><img src="man/figures/logo.png" align="right" height="40" alt="r-econid website" /></a>
 
 # econid
 
@@ -18,11 +18,11 @@ coverage](https://codecov.io/gh/Teal-Insights/r-econid/graph/badge.svg)](https:/
 ## Overview
 
 The `econid` R package is a foundational building block of the
-[econdataverse](https://econdataverse.org) family of packages aimed at
-helping economists and financial professionals work with sovereign-level
-economic data. The package is aimed at domain experts in economics and
-finance who need to analyze and join data across multiple sources, but
-who aren’t necessarily R programming experts.
+[econdataverse](https://www.econdataverse.org/) family of packages aimed
+at helping economists and financial professionals work with
+sovereign-level economic data. The package is aimed at domain experts in
+economics and finance who need to analyze and join data across multiple
+sources, but who aren’t necessarily R programming experts.
 
 ## Motivation
 
@@ -68,12 +68,12 @@ Researchers often need to:
 
 ## Design Philosophy
 
-The design philosophy of the package follows [tidyverse
-principles](https://www.tidyverse.org/principles/) and the [tidy tools
-manifesto](https://www.tidyverse.org/manifesto/). We strive to practice
-human-centered design, with clear documentation and examples and
-graceful handling of edge cases. We invite you to submit suggestions for
-improvements and extensions on the package’s [Github
+The design philosophy of the package follows [tidyverse design
+principles](https://design.tidyverse.org/) and the [tidy tools
+manifesto](https://tidyverse.tidyverse.org/articles/manifesto.html). We
+strive to practice human-centered design, with clear documentation and
+examples and graceful handling of edge cases. We invite you to submit
+suggestions for improvements and extensions on the package’s [Github
 Issues](https://github.com/Teal-Insights/r-econid/issues) page.
 
 We have designed the package to handle only the most common entities
@@ -84,8 +84,15 @@ flexibly accommodate any unconventional use case.
 
 ## Installation
 
-Until the package is published on CRAN, you can install it from GitHub
-using the `remotes` package.
+To install the package from CRAN, you can use the `install.packages()`
+function:
+
+``` r
+install.packages("econid")
+```
+
+To install a development version from GitHub, you can use the `remotes`
+package:
 
 ``` r
 remotes::install_github("Teal-Insights/r-econid")

--- a/README.rmd
+++ b/README.rmd
@@ -2,7 +2,7 @@
 output: github_document
 ---
 
-<a href="https://teal-insights.github.io/r-econid"><img src="man/figures/logo.png" align="right" height="40" alt="r-econid website" /></a>
+<a href="https://teal-insights.github.io/r-econid/"><img src="man/figures/logo.png" align="right" height="40" alt="r-econid website" /></a>
 
 # econid
 <!-- badges: start -->
@@ -15,7 +15,7 @@ output: github_document
 
 ## Overview
 
-The `econid` R package is a foundational building block of the [econdataverse](https://econdataverse.org) family of packages aimed at helping economists and financial professionals work with sovereign-level economic data. The package is aimed at domain experts in economics and finance who need to analyze and join data across multiple sources, but who aren't necessarily R programming experts.
+The `econid` R package is a foundational building block of the [econdataverse](https://www.econdataverse.org/) family of packages aimed at helping economists and financial professionals work with sovereign-level economic data. The package is aimed at domain experts in economics and finance who need to analyze and join data across multiple sources, but who aren't necessarily R programming experts.
 
 ## Motivation
 
@@ -56,13 +56,19 @@ Researchers often need to:
 
 ## Design Philosophy
 
-The design philosophy of the package follows [tidyverse principles](https://www.tidyverse.org/principles/) and the [tidy tools manifesto](https://www.tidyverse.org/manifesto/). We strive to practice human-centered design, with clear documentation and examples and graceful handling of edge cases. We invite you to submit suggestions for improvements and extensions on the package's [Github Issues](https://github.com/Teal-Insights/r-econid/issues) page.
+The design philosophy of the package follows [tidyverse design principles](https://design.tidyverse.org/) and the [tidy tools manifesto](https://tidyverse.tidyverse.org/articles/manifesto.html). We strive to practice human-centered design, with clear documentation and examples and graceful handling of edge cases. We invite you to submit suggestions for improvements and extensions on the package's [Github Issues](https://github.com/Teal-Insights/r-econid/issues) page.
 
 We have designed the package to handle only the most common entities financial and economic professionals might encounter in a dataset (249 in total), not to handle every edge case. However, the package allows users to extend the standardization list with custom entities to flexibly accommodate any unconventional use case.
 
 ## Installation
 
-Until the package is published on CRAN, you can install it from GitHub using the `remotes` package.
+To install the package from CRAN, you can use the `install.packages()` function:
+
+```r
+install.packages("econid")
+```
+
+To install a development version from GitHub, you can use the `remotes` package:
 
 ```r
 remotes::install_github("Teal-Insights/r-econid")

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,5 @@
+## R CMD check results
+
+0 errors | 0 warnings | 0 note
+
+* This is a new release.

--- a/data-raw/get_entity_pattern_test_cases.R
+++ b/data-raw/get_entity_pattern_test_cases.R
@@ -1,3 +1,18 @@
+# Install ellmer if not already present
+if (!requireNamespace("ellmer", quietly = TRUE)) {
+  install.packages("ellmer")
+}
+
+# Install dotenv if not already present
+if (!requireNamespace("dotenv", quietly = TRUE)) {
+  install.packages("dotenv")
+}
+
+# Install usethis if not already present
+if (!requireNamespace("usethis", quietly = TRUE)) {
+  install.packages("usethis")
+}
+
 dotenv::load_dot_env()
 
 system_patterns <- entity_patterns

--- a/data-raw/get_entity_patterns.R
+++ b/data-raw/get_entity_patterns.R
@@ -1,3 +1,8 @@
+# Install usethis if not already present
+if (!requireNamespace("usethis", quietly = TRUE)) {
+  install.packages("usethis")
+}
+
 entity_patterns <- tibble::tribble(
   ~entity_name, ~entity_regex, ~iso3c, ~iso2c,
 

--- a/data-raw/get_iso_codes.R
+++ b/data-raw/get_iso_codes.R
@@ -1,3 +1,8 @@
+# Install dotenv if not already present
+if (!requireNamespace("dotenv", quietly = TRUE)) {
+  install.packages("dotenv")
+}
+
 # Set API endpoint url
 url <- "https://rest-countries10.p.rapidapi.com/countries"
 

--- a/data-raw/get_wb_counterparts.R
+++ b/data-raw/get_wb_counterparts.R
@@ -1,3 +1,26 @@
+
+# Install httr2 if not already present
+if (!requireNamespace("httr2", quietly = TRUE)) {
+  install.packages("httr2")
+}
+
+# Install jsonlite if not already present
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+  install.packages("jsonlite")
+}
+
+if (!requireNamespace("usethis", quietly = TRUE)) {
+  install.packages("usethis")
+}
+
+if (!requireNamespace("tidyr", quietly = TRUE)) {
+  install.packages("tidyr")
+}
+
+if (!requireNamespace("stringr", quietly = TRUE)) {
+  install.packages("stringr")
+}
+
 library(httr2)
 library(jsonlite)
 library(dplyr)

--- a/man/list_entity_patterns.Rd
+++ b/man/list_entity_patterns.Rd
@@ -27,4 +27,3 @@ identifying economic indicators. It combines the patterns from the built-in
 patterns <- list_entity_patterns()
 
 }
-\keyword{internal}


### PR DESCRIPTION
- Make package name, description, and URLs more CRAN-compliant
- Add aspirational CRAN install instructions to the README
- Add `News.md` and `cran-comments.md`
- Remove Suggests dependencies that were only used in data-raw scripts, but `require` these directly in the scripts